### PR TITLE
Update storage.native peer dependancy package to currently up to date

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "module": "dist/use-state-persist.esm.js",
   "devDependencies": {
-    "@react-native-community/async-storage": "^1.11.0",
+    "@react-native-async-storage/async-storage": "^1.15.4",
     "@testing-library/react-hooks": "^3.3.0",
     "@types/faker": "^4.1.12",
     "@types/react": "^16.9.36",

--- a/src/storage/storage.native.ts
+++ b/src/storage/storage.native.ts
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StorageProvider, Data, StorageItem, StorageEvents } from './types';
 import { Event } from './event';
 

--- a/test/storage.native.test.ts
+++ b/test/storage.native.test.ts
@@ -2,7 +2,7 @@ import { arrayOfRandomStorageItems, keyName } from './utils';
 // @ts-ignore: Unreachable code error
 import MockAsyncStorage from 'mock-async-storage';
 import { syncStorage } from '../src/storage/storage.native';
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StorageItem } from '../src/storage/types';
 
 // function timeout(ms: number) {
@@ -11,10 +11,10 @@ import { StorageItem } from '../src/storage/types';
 
 const mock = () => {
   const mockImpl = new MockAsyncStorage();
-  jest.mock('@react-native-community/async-storage', () => mockImpl);
+  jest.mock('@react-native-async-storage/async-storage', () => mockImpl);
 };
 
-const release = () => jest.unmock('@react-native-community/async-storage');
+const release = () => jest.unmock('@react-native-async-storage/async-storage');
 
 beforeAll(async () => {
   mock();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,10 +1131,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@react-native-community/async-storage@^1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.11.0.tgz#bf81b8813080846f150c67f531987c429b442166"
-  integrity sha512-Pq9LlmvtCEKAGdkyrgTcRxNh2fnHFykEj2qnRYijOl1pDIl2MkD5IxaXu5eOL0wgOtAl4U//ff4z40Td6XR5rw==
+"@react-native-async-storage/async-storage@^1.15.4":
+  version "1.15.4"
+  resolved "https://verdaccio.internal.gendius.co.uk/@react-native-async-storage%2fasync-storage/-/async-storage-1.15.4.tgz#cdba464ca3bb9f10ec538342cbf2520c06f453ab"
+  integrity sha512-pC0MS6UBuv/YiVAxtzi7CgUed8oCQNYMtGt0yb/I9fI/BWTiJK5cj4YtW2XtL95K5IuvPX/6uGWaouZ8KqXwdg==
   dependencies:
     deep-assign "^3.0.0"
 
@@ -2679,7 +2679,7 @@ decode-uri-component@^0.2.0:
 
 deep-assign@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
+  resolved "https://verdaccio.internal.gendius.co.uk/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
   integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
   dependencies:
     is-obj "^1.0.0"
@@ -4075,7 +4075,7 @@ is-number@^3.0.0:
 
 is-obj@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  resolved "https://verdaccio.internal.gendius.co.uk/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:


### PR DESCRIPTION
Closes #13 

n.b. This is a breaking change, anyone using the old package will find it breaks after this update until they themselves upgrade to @react-native-async-storage/async-storage

It may be worth either waiting and putting this in a major release version, or re-writing this code so it can use either. Ideally the AsyncStorage instance should be injectable as config.