### PR TITLE
Allow getting boolean false value

### DIFF
--- a/src/use-state-persist.ts
+++ b/src/use-state-persist.ts
@@ -21,7 +21,7 @@ export const useStatePersist = <T>(
       const item = syncStorage.getItem<T>(storageNamespace + key);
       // Get item or else initial value
 
-      return item ? item : initialValue;
+      return item === null ? initialValue : item;
     } catch (error) {
       // If error also return initialValue
       console.error(error);


### PR DESCRIPTION
When item is false this condition will not work and hook will incorrectly return default value.
Fixed by checking on null value only. 

This fix the https://github.com/leoafarias/use-state-persist/issues/21